### PR TITLE
Chore/feedback ex3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "solidity.compileUsingRemoteVersion": "v0.8.24+commit.e11b9ed9"
+  "solidity.compileUsingRemoteVersion": "v0.8.24+commit.e11b9ed9",
+  "cSpell.words": ["nomicfoundation"]
 }

--- a/contracts/NftAuction.sol
+++ b/contracts/NftAuction.sol
@@ -134,6 +134,20 @@ contract Auction is Ownable {
         auctionId += 1;
     }
 
+    function getAuctionInfo(
+        uint256 _auctionId
+    ) external view returns (AuctionInfo memory) {
+        return auctions[_auctionId];
+    }
+
+    function getAllAuctions() external view returns (AuctionInfo[] memory) {
+        AuctionInfo[] memory result = new AuctionInfo[](auctionId - 1);
+        for (uint256 i = 1; i < auctionId; i++) {
+            result[i - 1] = auctions[i];
+        }
+        return result;
+    }
+
     function bid(
         uint256 _auctionId
     ) external payable auctionExists(_auctionId) bidable(_auctionId) {

--- a/contracts/NftAuction.sol
+++ b/contracts/NftAuction.sol
@@ -22,8 +22,8 @@ import "@openzeppelin/contracts/access/Ownable.sol";
     - Viết contract theo logic được vẽ từ diagram + unit test
  */
 
-contract MyToken is ERC721, Ownable {
-    constructor(address _owner) ERC721("TokenAuction", "TA") Ownable(_owner) {}
+contract NFT is ERC721, Ownable {
+    constructor(address _owner) ERC721("NFT", "NFT") Ownable(_owner) {}
 
     function mint(address to, uint256 tokenId) public onlyOwner {
         _safeMint(to, tokenId);
@@ -97,7 +97,7 @@ contract Auction is Ownable {
         uint256 startTime,
         uint256 endTime
     ) external {
-        MyToken nft = MyToken(tokenContract);
+        NFT nft = NFT(tokenContract);
         require(nft.ownerOf(tokenId) == msg.sender, "Not token owner");
         require(
             startTime > block.timestamp,
@@ -140,7 +140,7 @@ contract Auction is Ownable {
         uint256 tokenId
     ) external auctionExists(tokenId) bidable(tokenId) onlyTokenOwner(tokenId) {
         AuctionInfo storage auction = auctions[tokenId];
-        MyToken nft = MyToken(auction.tokenContract);
+        NFT nft = NFT(auction.tokenContract);
         if (auction.highestBidder == address(0)) {
             nft.transferFrom(address(this), msg.sender, tokenId);
         } else {
@@ -157,7 +157,7 @@ contract Auction is Ownable {
         uint256 tokenId
     ) external auctionExists(tokenId) claimable(tokenId) {
         AuctionInfo storage auction = auctions[tokenId];
-        MyToken nft = MyToken(auction.tokenContract);
+        NFT nft = NFT(auction.tokenContract);
 
         nft.transferFrom(address(this), msg.sender, tokenId);
         auction.isClaimed = true;
@@ -171,7 +171,7 @@ contract Auction is Ownable {
         uint256 tokenId
     ) public auctionExists(tokenId) onlyOwner {
         AuctionInfo storage auction = auctions[tokenId];
-        MyToken nft = MyToken(auction.tokenContract);
+        NFT nft = NFT(auction.tokenContract);
         nft.transferFrom(address(this), auction.owner, tokenId);
         payable(auction.highestBidder).transfer(auction.highestBid);
         auction.isClaimed = true;

--- a/contracts/NftAuction.sol
+++ b/contracts/NftAuction.sol
@@ -82,8 +82,8 @@ contract Auction is Ownable {
 
     modifier bidable(uint256 _auctionId) {
         require(
-            auctions[_auctionId].startTime < block.timestamp &&
-                auctions[_auctionId].endTime > block.timestamp,
+            auctions[_auctionId].startTime < block.number &&
+                auctions[_auctionId].endTime > block.number,
             "Auction not open"
         );
         _;
@@ -100,8 +100,8 @@ contract Auction is Ownable {
 
     modifier validTimeline(uint256 _startTime, uint256 _endTime) {
         require(
-            _startTime > block.timestamp,
-            "Start time should be > block timestamp"
+            _startTime > block.number,
+            "Start time should be > block number"
         );
         require(_endTime > _startTime, "End time should be > start time");
         _;
@@ -111,7 +111,7 @@ contract Auction is Ownable {
         auctionId = 1;
     }
 
-    function startAuction(
+    function addAuction(
         address _tokenContract,
         uint256 _tokenId,
         uint256 _amount,
@@ -178,7 +178,7 @@ contract Auction is Ownable {
         require(auction.highestBidder == address(0), "Already have bidder");
         nft.transferFrom(address(this), msg.sender, auction.tokenId);
 
-        auction.endTime = block.timestamp;
+        auction.endTime = block.number;
         auction.isClaimed = true;
         emit AuctionEnded(
             _auctionId,
@@ -216,6 +216,6 @@ contract Auction is Ownable {
             payable(auction.highestBidder).transfer(auction.highestBid);
         }
         auction.isClaimed = true;
-        auction.endTime = block.timestamp;
+        auction.endTime = block.number;
     }
 }

--- a/contracts/NftAuction.sol
+++ b/contracts/NftAuction.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+// import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
@@ -34,6 +35,12 @@ interface INFT {
     function ownerOf(uint256 tokenId) external view returns (address);
 
     function transferFrom(address from, address to, uint256 tokenId) external;
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
 }
 
 contract Auction is Ownable {
@@ -111,6 +118,18 @@ contract Auction is Ownable {
         auctionId = 1;
     }
 
+    // function onERC721Received(
+    //     address operator,
+    //     address from,
+    //     uint256 tokenId,
+    //     bytes calldata data
+    // ) external pure override returns (bytes4) {
+    //     return
+    //         bytes4(
+    //             keccak256("onERC721Received(address,address,uint256,bytes)")
+    //         );
+    // }
+
     function addAuction(
         address _tokenContract,
         uint256 _tokenId,
@@ -120,7 +139,7 @@ contract Auction is Ownable {
     ) external validTimeline(_startTime, _endTime) {
         INFT nft = INFT(_tokenContract);
         require(nft.ownerOf(_tokenId) == msg.sender, "Not token owner");
-
+        nft.transferFrom(msg.sender, address(this), _tokenId);
         auctions[auctionId] = AuctionInfo({
             owner: msg.sender,
             tokenId: _tokenId,
@@ -191,9 +210,9 @@ contract Auction is Ownable {
         uint256 _auctionId
     ) external auctionExists(_auctionId) claimable(_auctionId) {
         AuctionInfo storage auction = auctions[_auctionId];
-        NFT nft = NFT(auction.tokenContract);
+        INFT nft = INFT(auction.tokenContract);
 
-        nft.transferFrom(address(this), msg.sender, auction.tokenId);
+        nft.transferFrom(address(this), auction.highestBidder, auction.tokenId);
         payable(auction.owner).transfer(auction.highestBid);
 
         auction.isClaimed = true;
@@ -206,7 +225,7 @@ contract Auction is Ownable {
     ) public auctionExists(_auctionId) onlyOwner {
         AuctionInfo storage auction = auctions[_auctionId];
 
-        require(auction.endTime < block.number, "Auction not closed");
+        require(auction.endTime > block.number, "Auction closed");
 
         NFT nft = NFT(auction.tokenContract);
 

--- a/contracts/NftToken.sol
+++ b/contracts/NftToken.sol
@@ -27,8 +27,8 @@ contract NftToken is ERC721, Ownable {
 
     uint256 currentTokenId;
 
-    constructor() Ownable(msg.sender) ERC721("NftToken", "NFT") {
-        nftOwner = msg.sender;
+    constructor(address owner) Ownable(owner) ERC721("NftToken", "NFT") {
+        nftOwner = owner;
     }
 
     event NewBid(

--- a/contracts/NftToken.sol
+++ b/contracts/NftToken.sol
@@ -70,7 +70,7 @@ contract NftToken is ERC721, Ownable {
         );
 
         if (highestBidder != address(0)) {
-            payable(highestBidder).transfer(highestBidAmount);
+            highestBidder.transfer(highestBidAmount);
         }
         highestBidder = payable(msg.sender);
         highestBidAmount = msg.value;
@@ -83,15 +83,13 @@ contract NftToken is ERC721, Ownable {
             _mint(nftOwner, currentTokenId);
         } else {
             _mint(highestBidder, currentTokenId);
+            payable(nftOwner).transfer(highestBidAmount);
         }
+
         highestBidder = payable(address(0));
         highestBidAmount = 0;
         currentTokenId += 1;
 
         emit NewNft(currentTokenId);
-    }
-
-    function withdrawn() external onlyOwner {
-        payable(nftOwner).transfer(balanceOf(address(this)));
     }
 }

--- a/contracts/NftToken.sol
+++ b/contracts/NftToken.sol
@@ -29,6 +29,7 @@ contract NftToken is ERC721, Ownable {
 
     constructor(address owner) Ownable(owner) ERC721("NftToken", "NFT") {
         nftOwner = owner;
+        blockStart = block.number;
     }
 
     event NewBid(

--- a/contracts/NftToken.sol
+++ b/contracts/NftToken.sol
@@ -55,6 +55,14 @@ contract NftToken is ERC721, Ownable {
         _;
     }
 
+    function getHighestBid() external view returns (address, uint256) {
+        return (highestBidder, highestBidAmount);
+    }
+
+    function getCurrentTokenId() external view returns (uint256) {
+        return currentTokenId;
+    }
+
     function bid() external payable bidable {
         require(
             highestBidAmount < msg.value,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"devDependencies": {
 		"@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
 		"@nomicfoundation/hardhat-ethers": "^3.0.0",
-		"@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+		"@nomicfoundation/hardhat-network-helpers": "^1.0.10",
 		"@nomicfoundation/hardhat-toolbox": "^4.0.0",
 		"@nomicfoundation/hardhat-verify": "^2.0.0",
 		"@typechain/ethers-v6": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ devDependencies:
     specifier: ^3.0.0
     version: 3.0.5(ethers@6.11.1)(hardhat@2.21.0)
   '@nomicfoundation/hardhat-network-helpers':
-    specifier: ^1.0.0
+    specifier: ^1.0.10
     version: 1.0.10(hardhat@2.21.0)
   '@nomicfoundation/hardhat-toolbox':
     specifier: ^4.0.0

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -8,13 +8,11 @@ async function main() {
   await MyToken.deploy(owner);
 
   // ----- ex 2 ------
-
   const NftToken = await ethers.getContractFactory("NftToken");
-  await NftToken.deploy();
+  await NftToken.deploy(owner);
 
   // ----- ex 3 ------
-
-  const Nft = await ethers.getContractFactory("Auction");
+  const Nft = await ethers.getContractFactory("NFT");
   await Nft.deploy(owner);
 
   const Auction = await ethers.getContractFactory("Auction");

--- a/test/NftAuction.ts
+++ b/test/NftAuction.ts
@@ -1,0 +1,35 @@
+import {
+  loadFixture,
+  mine,
+} from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("Auction", function () {
+  async function deploy() {
+    const [owner, alice, bob, charlie, david, evan, ..._] =
+      await ethers.getSigners();
+
+    const NftToken = await ethers.getContractFactory("NFT");
+    const nftToken = await NftToken.deploy(owner);
+
+    await nftToken.mint(alice.address, 1);
+    await nftToken.mint(bob.address, 2);
+
+    const Auction = await ethers.getContractFactory("Auction");
+    const auction = await Auction.deploy(owner);
+
+    return { nftToken, auction, owner, alice, bob, charlie, david, evan };
+  }
+
+  it("Should start auction successful", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    await auction.connect(bob).addAuction(nftToken, 2, 100, 100, 500);
+
+    const aliceAuction = await auction.getAuctionInfo(1);
+    console.log("🚀 ~ aliceAuction:", aliceAuction);
+  });
+});

--- a/test/NftAuction.ts
+++ b/test/NftAuction.ts
@@ -22,14 +22,189 @@ describe("Auction", function () {
     return { nftToken, auction, owner, alice, bob, charlie, david, evan };
   }
 
-  it("Should start auction successful", async function () {
+  it("Should alice and bob add auction successful", async function () {
     const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
       await loadFixture(deploy);
 
+    await nftToken.connect(alice).approve(auction.getAddress(), 1);
     await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
-    await auction.connect(bob).addAuction(nftToken, 2, 100, 100, 500);
+
+    // auction id start at 1
+    const aliceAuction = await auction.getAuctionInfo(1);
+
+    expect(aliceAuction.tokenId).to.equal(1);
+    expect(aliceAuction.tokenContract).to.equal(await nftToken.getAddress());
+    expect(aliceAuction.highestBid).to.equal(100);
+    expect(aliceAuction.startTime).to.equal(100);
+    expect(aliceAuction.endTime).to.equal(500);
+
+    await nftToken.connect(bob).approve(auction, 2);
+    await auction.connect(bob).addAuction(nftToken, 2, 100, 400, 1000);
+
+    const bobAuction = await auction.getAuctionInfo(2);
+
+    expect(bobAuction.tokenId).to.equal(2);
+    expect(bobAuction.tokenContract).to.equal(await nftToken.getAddress());
+    expect(bobAuction.highestBid).to.equal(100);
+    expect(bobAuction.startTime).to.equal(400);
+    expect(bobAuction.endTime).to.equal(1000);
+  });
+
+  it("Should charlie bid alice auction successful", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+
+    await auction.connect(charlie).bid(1, { value: 200 });
 
     const aliceAuction = await auction.getAuctionInfo(1);
-    console.log("🚀 ~ aliceAuction:", aliceAuction);
+
+    expect(aliceAuction.highestBid).to.equal(200);
+    expect(aliceAuction.highestBidder).to.equal(charlie.address);
+  });
+
+  it("Should david bid alice auction successful when bid more than charlie bid before", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+
+    await auction.connect(charlie).bid(1, { value: 200 });
+    await auction.connect(david).bid(1, { value: 300 });
+
+    const aliceAuction = await auction.getAuctionInfo(1);
+    expect(aliceAuction.highestBid).to.equal(300);
+    expect(aliceAuction.highestBidder).to.equal(david.address);
+  });
+
+  it("Should charlie bid bob auction fail cause auction not exist", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await expect(
+      auction.connect(charlie).bid(1, { value: 200 })
+    ).to.be.revertedWith("Auction does not exist");
+  });
+
+  it("Should charlie bid bob auction fail cause not biddable time", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    await expect(
+      auction.connect(charlie).bid(1, { value: 200 })
+    ).to.be.revertedWith("Auction not open");
+  });
+
+  it("Should charlie bid bob auction fail cause not bid too low", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+    await expect(
+      auction.connect(charlie).bid(1, { value: 2 })
+    ).to.be.revertedWith("Bid too low");
+  });
+
+  it("Should alice end auction soon successful when no bidder", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+
+    await auction.connect(alice).endAuction(1);
+    expect(await nftToken.ownerOf(1)).to.equal(alice.address);
+
+    const aliceAuction = await auction.getAuctionInfo(1);
+    expect(aliceAuction.isClaimed).to.equal(true);
+  });
+
+  it("Should alice end auction soon fail cause already have bidder", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+    await auction.connect(charlie).bid(1, { value: 200 });
+
+    await expect(auction.connect(alice).endAuction(1)).to.be.revertedWith(
+      "Already have bidder"
+    );
+  });
+
+  it("Should claim alice auction successful", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+
+    await auction.connect(charlie).bid(1, { value: 200 });
+
+    mine(500);
+    await auction.connect(charlie).claimNFT(1);
+    const aliceAuction = await auction.getAuctionInfo(1);
+    expect(aliceAuction.isClaimed).to.equal(true);
+    expect(await nftToken.ownerOf(aliceAuction[1])).to.equal(charlie.address);
+  });
+
+  it("Should claim alice auction fail cause claimer not highest bidder", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+
+    await auction.connect(charlie).bid(1, { value: 200 });
+
+    mine(500);
+    await expect(auction.connect(alice).claimNFT(1)).to.be.revertedWith(
+      "Not the token highest bidder"
+    );
+  });
+
+  it("Should force end auction by admin during bid time successful", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+
+    await auction.connect(charlie).bid(1, { value: 200 });
+    await auction.connect(owner).forceEnded(1);
+
+    const aliceAuction = await auction.getAuctionInfo(1);
+    expect(aliceAuction.isClaimed).to.equal(true);
+    expect(await nftToken.ownerOf(1)).to.equal(alice.address);
+  });
+
+  it("Should force end auction by admin during bid time fail cause auction closed", async function () {
+    const { nftToken, auction, owner, alice, bob, charlie, david, evan } =
+      await loadFixture(deploy);
+
+    await nftToken.connect(alice).approve(auction, 1);
+    await auction.connect(alice).addAuction(nftToken, 1, 100, 100, 500);
+    mine(200);
+
+    await auction.connect(charlie).bid(1, { value: 200 });
+    mine(500);
+
+    await expect(auction.connect(owner).forceEnded(1)).to.be.revertedWith(
+      "Auction closed"
+    );
   });
 });

--- a/test/NftToken.ts
+++ b/test/NftToken.ts
@@ -80,15 +80,4 @@ describe("NftToken", function () {
     expect(ownerNft).to.equal(alice.address);
     expect(await nftToken.getCurrentTokenId()).to.equal(1);
   });
-
-  it("Should highest bidder claim nft when bid time end", async function () {
-    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
-    await nftToken.connect(alice).bid({ value: 10 });
-
-    mine(200);
-    await nftToken.claim();
-    const ownerNft = await nftToken.ownerOf(0);
-    expect(ownerNft).to.equal(alice.address);
-    expect(await nftToken.getCurrentTokenId()).to.equal(1);
-  });
 });

--- a/test/NftToken.ts
+++ b/test/NftToken.ts
@@ -1,117 +1,20 @@
-// import {
-//   time,
-//   loadFixture,
-// } from "@nomicfoundation/hardhat-toolbox/network-helpers";
-// import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
-// import { expect } from "chai";
-// import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
 
-// describe("NftToken", function () {
-//   async function deploy() {
-//     const [owner, ...addresses]  = await ethers.getSigners();
+describe("NftToken", function () {
+  async function deploy() {
+    const [owner, alice, bob, charlie, ..._] = await ethers.getSigners();
 
-//     const NftToken = await ethers.getContractFactory("NftToken");
-//     const nftToken = await NftToken.deploy();
+    const NftToken = await ethers.getContractFactory("NftToken");
+    const nftToken = await NftToken.deploy(owner);
 
-//     return { nftToken, owner, addresses };
-//   }
+    return { nftToken, owner, alice, bob, charlie };
+  }
 
-//   describe("Deployment", function () {
-//     it("Should set the right unlockTime", async function () {
-//       const { lock, unlockTime } = await loadFixture(deployOneYearLockFixture);
+  it("Should deploy contract successful, with blockStart is current block number", async function () {
+    const { nftToken, owner, alice, bob, charlie } = await loadFixture(deploy);
 
-//       expect(await lock.unlockTime()).to.equal(unlockTime);
-//     });
-
-//     it("Should set the right owner", async function () {
-//       const { lock, owner } = await loadFixture(deployOneYearLockFixture);
-
-//       expect(await lock.owner()).to.equal(owner.address);
-//     });
-
-//     it("Should receive and store the funds to lock", async function () {
-//       const { lock, lockedAmount } = await loadFixture(
-//         deployOneYearLockFixture
-//       );
-
-//       expect(await ethers.provider.getBalance(lock.target)).to.equal(
-//         lockedAmount
-//       );
-//     });
-
-//     it("Should fail if the unlockTime is not in the future", async function () {
-//       // We don't use the fixture here because we want a different deployment
-//       const latestTime = await time.latest();
-//       const Lock = await ethers.getContractFactory("Lock");
-//       await expect(Lock.deploy(latestTime, { value: 1 })).to.be.revertedWith(
-//         "Unlock time should be in the future"
-//       );
-//     });
-//   });
-
-//   describe("Withdrawals", function () {
-//     describe("Validations", function () {
-//       it("Should revert with the right error if called too soon", async function () {
-//         const { lock } = await loadFixture(deployOneYearLockFixture);
-
-//         await expect(lock.withdraw()).to.be.revertedWith(
-//           "You can't withdraw yet"
-//         );
-//       });
-
-//       it("Should revert with the right error if called from another account", async function () {
-//         const { lock, unlockTime, otherAccount } = await loadFixture(
-//           deployOneYearLockFixture
-//         );
-
-//         // We can increase the time in Hardhat Network
-//         await time.increaseTo(unlockTime);
-
-//         // We use lock.connect() to send a transaction from another account
-//         await expect(lock.connect(otherAccount).withdraw()).to.be.revertedWith(
-//           "You aren't the owner"
-//         );
-//       });
-
-//       it("Shouldn't fail if the unlockTime has arrived and the owner calls it", async function () {
-//         const { lock, unlockTime } = await loadFixture(
-//           deployOneYearLockFixture
-//         );
-
-//         // Transactions are sent using the first signer by default
-//         await time.increaseTo(unlockTime);
-
-//         await expect(lock.withdraw()).not.to.be.reverted;
-//       });
-//     });
-
-//     describe("Events", function () {
-//       it("Should emit an event on withdrawals", async function () {
-//         const { lock, unlockTime, lockedAmount } = await loadFixture(
-//           deployOneYearLockFixture
-//         );
-
-//         await time.increaseTo(unlockTime);
-
-//         await expect(lock.withdraw())
-//           .to.emit(lock, "Withdrawal")
-//           .withArgs(lockedAmount, anyValue); // We accept any value as `when` arg
-//       });
-//     });
-
-//     describe("Transfers", function () {
-//       it("Should transfer the funds to the owner", async function () {
-//         const { lock, unlockTime, lockedAmount, owner } = await loadFixture(
-//           deployOneYearLockFixture
-//         );
-
-//         await time.increaseTo(unlockTime);
-
-//         await expect(lock.withdraw()).to.changeEtherBalances(
-//           [owner, lock],
-//           [lockedAmount, -lockedAmount]
-//         );
-//       });
-//     });
-//   });
-// });
+    expect(await nftToken.getCurrentBlock()).to.equal(0);
+  });
+});

--- a/test/NftToken.ts
+++ b/test/NftToken.ts
@@ -1,20 +1,94 @@
-import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import {
+  loadFixture,
+  mine,
+} from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
 describe("NftToken", function () {
   async function deploy() {
-    const [owner, alice, bob, charlie, ..._] = await ethers.getSigners();
+    const [owner, alice, bob, ..._] = await ethers.getSigners();
 
     const NftToken = await ethers.getContractFactory("NftToken");
     const nftToken = await NftToken.deploy(owner);
 
-    return { nftToken, owner, alice, bob, charlie };
+    return { nftToken, owner, alice, bob };
   }
 
-  it("Should deploy contract successful, with blockStart is current block number", async function () {
-    const { nftToken, owner, alice, bob, charlie } = await loadFixture(deploy);
+  it("Should bid successful when biddable", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
 
-    expect(await nftToken.getCurrentBlock()).to.equal(0);
+    await nftToken.connect(alice).bid({ value: 100 });
+
+    const [highestBidder, highestBid] = await nftToken.getHighestBid();
+
+    expect(highestBid).to.equal(100);
+    expect(highestBidder).to.equal(alice.address);
+  });
+
+  it("Should raise error if bid when cannot biddable", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
+    await nftToken.connect(alice).bid({ value: 10 });
+    await nftToken.connect(bob).bid({ value: 30 });
+
+    mine(200);
+    await expect(
+      nftToken.connect(alice).bid({ value: 100 })
+    ).to.be.revertedWith("Auction not open");
+  });
+
+  it("Should update highest bidder is bob when alice bid 10 then bob bid 30", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
+    await nftToken.connect(alice).bid({ value: 10 });
+    await nftToken.connect(bob).bid({ value: 30 });
+
+    const [highestBidder, highestBid] = await nftToken.getHighestBid();
+
+    expect(highestBid).to.equal(30);
+    expect(highestBidder).to.equal(bob.address);
+  });
+
+  it("Should raise error when bob bid lower than highest bid", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
+    await nftToken.connect(alice).bid({ value: 30 });
+    await expect(nftToken.connect(bob).bid({ value: 10 })).to.be.revertedWith(
+      "Bid must be higher than the highest bid"
+    );
+  });
+
+  it("Should raise error when claim in bid time", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
+    await expect(nftToken.claim()).to.be.revertedWith("Auction not closed");
+  });
+
+  it("Should owner claim nft when no one bid and generate new nft", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
+    mine(200);
+    await nftToken.claim();
+    const ownerNft = await nftToken.ownerOf(0);
+    expect(ownerNft).to.equal(owner.address);
+    expect(await nftToken.getCurrentTokenId()).to.equal(1);
+  });
+
+  it("Should highest bidder claim nft when bid time end", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
+    await nftToken.connect(alice).bid({ value: 10 });
+
+    mine(200);
+    await nftToken.claim();
+    const ownerNft = await nftToken.ownerOf(0);
+    expect(ownerNft).to.equal(alice.address);
+    expect(await nftToken.getCurrentTokenId()).to.equal(1);
+  });
+
+  it("Should highest bidder claim nft when bid time end", async function () {
+    const { nftToken, owner, alice, bob } = await loadFixture(deploy);
+    await nftToken.connect(alice).bid({ value: 10 });
+
+    mine(200);
+    await nftToken.claim();
+    const ownerNft = await nftToken.ownerOf(0);
+    expect(ownerNft).to.equal(alice.address);
+    expect(await nftToken.getCurrentTokenId()).to.equal(1);
   });
 });


### PR DESCRIPTION
NFTAuction

- Vấn đề về lưu biến auctions:
```
    mapping(uint256 => AuctionInfo) public auctions;
```
  Nếu khác contracts adress, chung token Id => không thể tạo auction được

- Line 100:
```
  MyToken nft = MyToken(tokenContract);
```
  - Dùng interface thay thế cho `MyToken`


- Line 101:
```
  nft.transferFrom(msg.sender, address(this), tokenId);
```
  - Không cần thiết, vì đã có `approve` thì function transferFrom mới chạy đc 

- Line 115: 
```
  highestBidder: payable(address(0)),
```
- Bỏ payable 

- Line 125 -> 134:
```
  AuctionInfo memory auction = auctions[tokenId];

  require(msg.value > auction.highestBid, "Bid too low");

  if (auction.highestBidder != address(0)) {
      auction.highestBidder.transfer(auction.highestBid);
  }

  auction.highestBid = msg.value;
  auction.highestBidder = payable(msg.sender);
```
  Auction data được load dưới dạng memory, nên không thể thay đổi được giá trị trong contract
  Sửa lại phần này


- Line 143: Dùng interface thay thế

- 2 function endAuction và claimNFT:
  + Thiếu check auction đã kết thúc/ claim chưa
  + Cả 2 đều cùng chung một đích là kết thúc auction thì không cần phải tách làm 2 functions riêng biệt, hoặc đã tách thì phải kiểm tra điều kiện auction đã kết thúc rồi mới claim được

- Hàm endAuction:
  + Người bán chỉ có thể hủy đấu giá trước thời hạn nếu không có người đấu giá

- Hàm claimNFT:
  + hành động claim cũng tương đướng với việc kết thúc auction, thiêu cập nhật endAt

- hàm ForceEnded:
  + Thiếu check auction đã kết thúc chưa
  + highest bidder là null thì tiền highestBid phải chuyển là tiền của contract => lỗi nghiêm trọng